### PR TITLE
Updated package.json rename file feature

### DIFF
--- a/diagrams/package.json
+++ b/diagrams/package.json
@@ -24,8 +24,9 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
-    "postbuild": "copyfiles -f build/**/*.js build/**/*.css ../vscode-plugin/webview-ui/",
+    "build": "react-scripts build && npm run rename-files",
+    "rename-files": "rename build\\static\\js\\main.*.js main.js && rename build\\static\\css\\main.*.css main.css",
+    "postbuild": "copyfiles -f build/**/main.js build/**/main.css ../vscode-plugin/webview-ui/",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
## Purpose
> The purpose of the following change would be to provide a clear indication in relation to the naming conventions associated to the creation of a WSO2 ESB project
> Add missing onCommand extensions as some of the services are not available per default.
> Refactored some naming conventions as they were too abstract.

## Goals
> This specific feature would provide the user/developer with the ability to clearly define and name the artifactId as well as the ability to provide a groupId associated to the WSO2 ESB project.